### PR TITLE
Dataset-Listing: Look and Feel from old UI

### DIFF
--- a/projects/wave-core-new/src/lib/backend/backend.service.ts
+++ b/projects/wave-core-new/src/lib/backend/backend.service.ts
@@ -232,17 +232,18 @@ export class BackendService {
     }
 
     // TODO: turn into paginated data source
-    getDatasets(sessionId: UUID): Observable<Array<DatasetDict>> {
+    getDatasets(sessionId: UUID, offset='0', limit='20'): Observable<Array<DatasetDict>> {
         const params = new NullDiscardingHttpParams();
         params.set('order', 'NameAsc');
-        params.set('offset', '0');
-        params.set('limit', '20');
+        params.set('offset', offset);
+        params.set('limit', limit);
 
         return this.http.get<Array<DatasetDict>>(this.config.API_URL + '/datasets', {
             params: params.httpParams,
             headers: BackendService.authorizationHeader(sessionId),
         });
     }
+
 
     getDataset(sessionId: UUID, datasetId: DatasetIdDict): Observable<DatasetDict> {
         // TODO: external datasets

--- a/projects/wave-core-new/src/lib/datasets/dataset-list/dataset-list.component.html
+++ b/projects/wave-core-new/src/lib/datasets/dataset-list/dataset-list.component.html
@@ -1,7 +1,36 @@
 <wave-sidenav-header>Data Repository</wave-sidenav-header>
-
+<!--
 <mat-list>
     <ng-template ngFor let-dataset [ngForOf]="datasets | async">
         <wave-dataset [dataset]="dataset"></wave-dataset>
     </ng-template>
 </mat-list>
+-->
+<mat-table  [dataSource]="datasets" class="mat-elevation-z8">
+    <mat-header-row  *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row  *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    <ng-container matColumnDef="id">
+        <mat-header-cell *matHeaderCellDef> ID </mat-header-cell>
+        <mat-cell  *matCellDef="let element"> {{element.id.Internal}} </mat-cell>
+    </ng-container>
+    <ng-container matColumnDef="name">
+        <mat-header-cell  *matHeaderCellDef> Name </mat-header-cell>
+        <mat-cell *matCellDef="let element"> {{element.name}} </mat-cell>
+    </ng-container>
+    <ng-container matColumnDef="description">
+        <mat-header-cell  *matHeaderCellDef> Description </mat-header-cell>
+        <mat-cell *matCellDef="let element"> {{element.description}} </mat-cell>
+    </ng-container>
+    <ng-container matColumnDef="add">
+        <mat-header-cell *matHeaderCellDef>Actions</mat-header-cell>
+        <mat-cell  *matCellDef="let element">
+            <button type="button" mat-raised-button (click)="add(element)">Add</button>
+        </mat-cell>
+    </ng-container>
+</mat-table>
+<mat-paginator
+    [length]="100"
+    [pageSize]="5"
+    [pageSizeOptions]="[1, 2, 3, 5, 10]"
+    (page)="pageEvent= $event; onPaginationChange($event)">
+</mat-paginator>

--- a/projects/wave-core-new/src/lib/datasets/dataset-list/dataset-list.component.scss
+++ b/projects/wave-core-new/src/lib/datasets/dataset-list/dataset-list.component.scss
@@ -1,0 +1,13 @@
+table {
+    width: 100%;
+}
+.mat-header-row,
+.mat-row {
+    display: inline-flex;
+    min-width: 100%;
+    height: auto;
+
+}
+.mat-header-cell, .mat-cell {
+    padding-right: 20px;
+}

--- a/projects/wave-core-new/src/lib/datasets/dataset-list/dataset-list.component.ts
+++ b/projects/wave-core-new/src/lib/datasets/dataset-list/dataset-list.component.ts
@@ -2,6 +2,7 @@ import {Component, OnInit, ChangeDetectionStrategy} from '@angular/core';
 import {Observable} from 'rxjs';
 import {Dataset} from '../dataset.model';
 import {DatasetService} from '../dataset.service';
+import {PageEvent} from '@angular/material/paginator';
 
 @Component({
     selector: 'wave-dataset-list',
@@ -11,12 +12,25 @@ import {DatasetService} from '../dataset.service';
 })
 export class DatasetListComponent implements OnInit {
     searchTerm = '';
-    // TODO: paginated data source
+    pageEvent: PageEvent | undefined;
+    offset = '0';
+    limit = '5';
     datasets: Observable<Array<Dataset>>;
-
+    displayedColumns: string[] = ['id','name','description','add'];
     constructor(public datasetService: DatasetService) {
-        this.datasets = this.datasetService.getDatasets();
+        this.datasets = this.datasetService.getDatasets(this.offset,this.limit);
     }
 
     ngOnInit(): void {}
+
+    add(dataset:Dataset): void {
+        this.datasetService.addDatasetToMap(dataset).subscribe();
+    }
+    onPaginationChange(event:PageEvent):void{
+        const page = event.pageIndex;
+        const size = event.pageSize;
+        this.offset = (page*size).toString();
+        this.limit = size.toString();
+        this.datasets = this.datasetService.getDatasets(this.offset, this.limit)
+    }
 }

--- a/projects/wave-core-new/src/lib/datasets/dataset.service.ts
+++ b/projects/wave-core-new/src/lib/datasets/dataset.service.ts
@@ -32,9 +32,9 @@ export class DatasetService {
         protected randomColorService: RandomColorService,
     ) {}
 
-    getDatasets(): Observable<Array<Dataset>> {
+    getDatasets(offset='0', limit='20'): Observable<Array<Dataset>> {
         return this.userService.getSessionStream().pipe(
-            mergeMap((session) => this.backend.getDatasets(session.sessionToken)),
+            mergeMap((session) => this.backend.getDatasets(session.sessionToken, offset, limit)),
             map((datasetDicts) => datasetDicts.map((dict) => Dataset.fromDict(dict))),
         );
     }
@@ -45,7 +45,6 @@ export class DatasetService {
             map((dict) => Dataset.fromDict(dict)),
         );
     }
-
     upload(form: FormData): Observable<HttpEvent<UploadResponseDict>> {
         return this.userService.getSessionTokenForRequest().pipe(mergeMap((token) => this.backend.upload(token, form)));
     }


### PR DESCRIPTION
Display Datasets as Material-Table & Paginate the Datatable
- Datasets as DataSource for mat-table
- paginated view
- datasource changes on pagination change
- (unfortunately no infinite scroll)