### PR TITLE
only call workflow methds for current session and once

### DIFF
--- a/projects/wave-core-new/src/lib/project/project.service.ts
+++ b/projects/wave-core-new/src/lib/project/project.service.ts
@@ -334,26 +334,28 @@ export class ProjectService {
     }
 
     registerWorkflow(workflow: WorkflowDict): Observable<UUID> {
-        return this.userService.getSessionStream().pipe(
-            mergeMap((session) => this.backend.registerWorkflow(workflow, session.sessionToken)),
+        return this.userService.getSessionTokenForRequest().pipe(
+            mergeMap((sessionToken) => this.backend.registerWorkflow(workflow, sessionToken)),
             map((response) => response.id),
         );
     }
 
     getWorkflow(workflowId: UUID): Observable<WorkflowDict> {
-        return this.userService.getSessionStream().pipe(mergeMap((session) => this.backend.getWorkflow(workflowId, session.sessionToken)));
+        return this.userService
+            .getSessionTokenForRequest()
+            .pipe(mergeMap((sessionToken) => this.backend.getWorkflow(workflowId, sessionToken)));
     }
 
     getWorkflowMetaData(workflowId: UUID): Observable<ResultDescriptorDict> {
         return this.userService
-            .getSessionStream()
-            .pipe(mergeMap((session) => this.backend.getWorkflowMetadata(workflowId, session.sessionToken)));
+            .getSessionTokenForRequest()
+            .pipe(mergeMap((sessionToken) => this.backend.getWorkflowMetadata(workflowId, sessionToken)));
     }
 
     getWorkflowProvenance(workflowId: UUID): Observable<Array<ProvenanceOutputDict>> {
         return this.userService
-            .getSessionStream()
-            .pipe(mergeMap((session) => this.backend.getWorkflowProvenance(workflowId, session.sessionToken)));
+            .getSessionTokenForRequest()
+            .pipe(mergeMap((sessionToken) => this.backend.getWorkflowProvenance(workflowId, sessionToken)));
     }
 
     /**


### PR DESCRIPTION
The problem was that within the get-*-workflow methods was a call to the session stream. But the stream would be updated and so a new request would be made. This would fail, if the new session cannot access the data of the previous user.

To fix this, I used the `sessionTokenForRequest` method that only emits ONCE.