### PR TITLE
Save closing of splash-screen in the localstorage

### DIFF
--- a/projects/gfbio-app/src/app/app.component.ts
+++ b/projects/gfbio-app/src/app/app.component.ts
@@ -240,7 +240,10 @@ export class AppComponent implements OnInit, AfterViewInit {
                     this.dialog.open(BasketDialogComponent, {data: {result}});
                 });
             } else {
-                this.dialog.open(SplashDialogComponent, {});
+                const showSplash = this.userService.getSettingFromLocalStorage('showStartupSplashScreen');
+                if (showSplash === null || JSON.parse(showSplash)) {
+                    this.dialog.open(SplashDialogComponent, {});
+                }
             }
         });
     }

--- a/projects/gfbio-app/src/app/app.component.ts
+++ b/projects/gfbio-app/src/app/app.component.ts
@@ -240,7 +240,7 @@ export class AppComponent implements OnInit, AfterViewInit {
                     this.dialog.open(BasketDialogComponent, {data: {result}});
                 });
             } else {
-                const showSplash = this.userService.getSettingFromLocalStorage('showStartupSplashScreen');
+                const showSplash = this.userService.getSettingFromLocalStorage(SplashDialogComponent.SPLASH_DIALOG_NAME);
                 if (showSplash === null || JSON.parse(showSplash)) {
                     this.dialog.open(SplashDialogComponent, {});
                 }

--- a/projects/gfbio-app/src/app/splash-dialog/splash-dialog.component.html
+++ b/projects/gfbio-app/src/app/splash-dialog/splash-dialog.component.html
@@ -15,7 +15,4 @@
         sharing for biological and environmental research.
     </p>
 </mat-dialog-content>
-<!-- TODO: reenable checkbox -->
-<!-- <mat-dialog-actions align="end">
-    <mat-checkbox (change)="changeTick($event)">Don't show this message again</mat-checkbox>
-</mat-dialog-actions> -->
+<wave-dialog-splash-checkbox [splashScreenName]="splashName"></wave-dialog-splash-checkbox>

--- a/projects/gfbio-app/src/app/splash-dialog/splash-dialog.component.scss
+++ b/projects/gfbio-app/src/app/splash-dialog/splash-dialog.component.scss
@@ -1,7 +1,3 @@
-mat-checkbox {
-    height: 2rem;
-}
-
 img {
     vertical-align: middle;
     height: 41px;

--- a/projects/gfbio-app/src/app/splash-dialog/splash-dialog.component.ts
+++ b/projects/gfbio-app/src/app/splash-dialog/splash-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, ChangeDetectionStrategy} from '@angular/core';
+import {Component, ChangeDetectionStrategy, OnInit} from '@angular/core';
 
 @Component({
     selector: 'wave-gfbio-splash-dialog',
@@ -6,8 +6,10 @@ import {Component, ChangeDetectionStrategy} from '@angular/core';
     styleUrls: ['./splash-dialog.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SplashDialogComponent {
-    // changeTick(event: MatCheckboxChange): void {
-    //     // TODO: remember user has clicked this
-    // }
+export class SplashDialogComponent implements OnInit {
+    splashName = 'showStartupSplashScreen';
+
+    constructor() {}
+
+    ngOnInit(): void {}
 }

--- a/projects/gfbio-app/src/app/splash-dialog/splash-dialog.component.ts
+++ b/projects/gfbio-app/src/app/splash-dialog/splash-dialog.component.ts
@@ -7,9 +7,13 @@ import {Component, ChangeDetectionStrategy, OnInit} from '@angular/core';
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SplashDialogComponent implements OnInit {
-    splashName = 'showStartupSplashScreen';
+    static SPLASH_DIALOG_NAME = 'showStartupSplashScreen';
 
     constructor() {}
 
     ngOnInit(): void {}
+
+    get splashName(): string {
+        return SplashDialogComponent.SPLASH_DIALOG_NAME;
+    }
 }

--- a/projects/wave-core-new/src/lib/dialogs/dialog-splash-checkbox/dialog-splash-checkbox.component.html
+++ b/projects/wave-core-new/src/lib/dialogs/dialog-splash-checkbox/dialog-splash-checkbox.component.html
@@ -1,0 +1,3 @@
+<mat-dialog-actions align="end">
+    <mat-checkbox (change)="changeCheckbox($event)">Don't show this message again</mat-checkbox>
+</mat-dialog-actions>

--- a/projects/wave-core-new/src/lib/dialogs/dialog-splash-checkbox/dialog-splash-checkbox.component.scss
+++ b/projects/wave-core-new/src/lib/dialogs/dialog-splash-checkbox/dialog-splash-checkbox.component.scss
@@ -1,0 +1,3 @@
+mat-checkbox {
+    height: 2rem;
+}

--- a/projects/wave-core-new/src/lib/dialogs/dialog-splash-checkbox/dialog-splash-checkbox.component.ts
+++ b/projects/wave-core-new/src/lib/dialogs/dialog-splash-checkbox/dialog-splash-checkbox.component.ts
@@ -1,0 +1,23 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {MatCheckboxChange} from '@angular/material/checkbox';
+import {UserService} from '../../users/user.service';
+
+@Component({
+    selector: 'wave-dialog-splash-checkbox',
+    templateUrl: './dialog-splash-checkbox.component.html',
+    styleUrls: ['./dialog-splash-checkbox.component.scss'],
+})
+export class DialogSplashCheckboxComponent implements OnInit {
+    /**
+     * The name is used as the key in LocalStorage.
+     */
+    @Input() splashScreenName!: string;
+
+    constructor(private readonly userService: UserService) {}
+
+    ngOnInit(): void {}
+
+    changeCheckbox(event: MatCheckboxChange): void {
+        this.userService.saveSettingInLocalStorage(this.splashScreenName, JSON.stringify(!event.checked));
+    }
+}

--- a/projects/wave-core-new/src/lib/users/user.service.ts
+++ b/projects/wave-core-new/src/lib/users/user.service.ts
@@ -173,6 +173,14 @@ export class UserService {
         this.logoutCallback = callback;
     }
 
+    saveSettingInLocalStorage(keyValue: string, setting: string): void {
+        localStorage.setItem(PATH_PREFIX + keyValue, setting);
+    }
+
+    getSettingFromLocalStorage(keyValue: string): string | null {
+        return localStorage.getItem(PATH_PREFIX + keyValue);
+    }
+
     protected saveSessionInBrowser(session: Session | undefined): void {
         if (session) {
             localStorage.setItem(PATH_PREFIX + 'session', session.sessionToken);

--- a/projects/wave-core-new/src/lib/wave-core.module.ts
+++ b/projects/wave-core-new/src/lib/wave-core.module.ts
@@ -128,6 +128,7 @@ import {LayerCollectionListComponent} from './layer-collections/layer-collection
 import {LayerCollectionNavigationComponent} from './layer-collections/layer-collection-navigation/layer-collection-navigation.component';
 import {ClassHistogramOperatorComponent} from './operators/dialogs/class-histogram-operator/class-histogram-operator.component';
 import {ColumnRangeFilterComponent} from './operators/dialogs/column-range-filter/column-range-filter.component';
+import {DialogSplashCheckboxComponent} from './dialogs/dialog-splash-checkbox/dialog-splash-checkbox.component';
 
 export const MATERIAL_MODULES = [
     MatAutocompleteModule,
@@ -198,6 +199,7 @@ const WAVE_COMPONENTS = [
     DialogHeaderComponent,
     DialogHelpComponent,
     DialogSectionHeadingComponent,
+    DialogSplashCheckboxComponent,
     DragAndDropComponent,
     DrawFeaturesComponent,
     ExpressionOperatorComponent,

--- a/projects/wave-core-new/src/public-api.ts
+++ b/projects/wave-core-new/src/public-api.ts
@@ -98,6 +98,7 @@ export * from './lib/util/components/code-editor.component';
 export * from './lib/util/directives/autocomplete-select.directive';
 export * from './lib/time/time-slider/time-slider.component';
 export * from './lib/operators/dialogs/column-range-filter/column-range-filter.component';
+export * from './lib/dialogs/dialog-splash-checkbox/dialog-splash-checkbox.component';
 
 // Pipes
 export * from './lib/util/pipes/async-converters.pipe';


### PR DESCRIPTION
In wave-core-new:

- add a new component  dialogs/dialog-splash-checkbox
- in user.service.ts  I added the two new methods to save/get the settings to/from the LocalStorage

in gfbio-app:
update  splash-dialog-component : add wave-dialog-splash-checkbox
