### PR TITLE
Time slider hidden when there is no time to select

### DIFF
--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
@@ -12,6 +12,6 @@
     <span>{{ currentTimeFormatted | async }}</span>
 </div>
 
-<div *ngIf="!(displayTimeLine())" class="padded container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
+<div *ngIf="!displayTimeLine()" class="padded container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
     <span>Point in Time: {{ currentTimeFormatted | async }}</span>
 </div>

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="displayTimeLine()" class="container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
+<div *ngIf="displayTimeSlider()" class="container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
     <mat-slider
         thumbLabel="true"
         [min]="min"
@@ -12,6 +12,6 @@
     <span>{{ currentTimeFormatted | async }}</span>
 </div>
 
-<div *ngIf="!displayTimeLine()" class="padded mat-typography">
+<div *ngIf="!displayTimeSlider()" class="padded mat-typography">
     <span>{{ currentTimeFormatted | async }}</span>
 </div>

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
@@ -1,4 +1,4 @@
-<div class="container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
+<div *ngIf="displayTimeLine()" class="container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
     <mat-slider
         thumbLabel="true"
         [min]="min"

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
@@ -13,5 +13,5 @@
 </div>
 
 <div *ngIf="!displayTimeLine()" class="padded container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
-    <span>Point in Time: {{ currentTimeFormatted | async }}</span>
+    <span>{{ currentTimeFormatted | async }}</span>
 </div>

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
@@ -12,6 +12,7 @@
     <span>{{ currentTimeFormatted | async }}</span>
 </div>
 
-<div *ngIf="!displayTimeLine()" class="padded  mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
+<!-- <div *ngIf="!displayTimeLine()" class="padded  mat-typography" fxLayout="row" fxLayoutAlign="space-between center"> -->
+<div *ngIf="!displayTimeLine()" class="padded mat-typography"> 
     <span>{{ currentTimeFormatted | async }}</span>
 </div>

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
@@ -12,7 +12,6 @@
     <span>{{ currentTimeFormatted | async }}</span>
 </div>
 
-<!-- <div *ngIf="!displayTimeLine()" class="padded  mat-typography" fxLayout="row" fxLayoutAlign="space-between center"> -->
-<div *ngIf="!displayTimeLine()" class="padded mat-typography"> 
+<div *ngIf="!displayTimeLine()" class="padded mat-typography">
     <span>{{ currentTimeFormatted | async }}</span>
 </div>

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
@@ -12,6 +12,6 @@
     <span>{{ currentTimeFormatted | async }}</span>
 </div>
 
-<div *ngIf="!displayTimeLine()" class="padded container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
+<div *ngIf="!displayTimeLine()" class="padded  mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
     <span>{{ currentTimeFormatted | async }}</span>
 </div>

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.html
@@ -11,3 +11,7 @@
     ></mat-slider>
     <span>{{ currentTimeFormatted | async }}</span>
 </div>
+
+<div *ngIf="!(displayTimeLine())" class="padded container mat-typography" fxLayout="row" fxLayoutAlign="space-between center">
+    <span>Point in Time: {{ currentTimeFormatted | async }}</span>
+</div>

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.scss
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.scss
@@ -8,7 +8,6 @@
 
 .padded {
     padding: 1rem;
-    padding-left: 2rem;
 }
 
 mat-slider {

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.scss
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.scss
@@ -6,6 +6,10 @@
     }
 }
 
+.padded {
+    padding: 1rem;
+}
+
 mat-slider {
     width: 100%;
     margin: 0 1rem;

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.scss
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.scss
@@ -7,7 +7,8 @@
 }
 
 .padded {
-    padding: 1rem;
+    padding: 0.85rem;
+    margin: 0 0.2rem;
 }
 
 mat-slider {

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.scss
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.scss
@@ -8,6 +8,7 @@
 
 .padded {
     padding: 1rem;
+    padding-left: 2rem;
 }
 
 mat-slider {

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.ts
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.ts
@@ -94,4 +94,8 @@ export class TimeStepSelectorComponent implements OnInit, OnChanges, OnDestroy {
             return timeStep.start.format(this.timeFormat);
         };
     }
+
+    displayTimeLine(): boolean {
+        return this.timeSteps !== undefined && this.timeSteps.length > 1 ? true : false;
+    }
 }

--- a/projects/core/src/lib/time/time-step-selector/time-step-selector.component.ts
+++ b/projects/core/src/lib/time/time-step-selector/time-step-selector.component.ts
@@ -102,7 +102,7 @@ export class TimeStepSelectorComponent implements OnInit, OnChanges, OnDestroy {
         };
     }
 
-    displayTimeLine(): boolean {
+    displayTimeSlider(): boolean {
         return this.timeSteps !== undefined && this.timeSteps.length > 1 ? true : false;
     }
 }


### PR DESCRIPTION
The time slider is hidden when only one timestep exists, i.e. there is nothing to select.