### PR TITLE
Datatable: Hideable columns

### DIFF
--- a/projects/core/src/lib/datatable/table/table.component.html
+++ b/projects/core/src/lib/datatable/table/table.component.html
@@ -69,7 +69,7 @@
 <mat-form-field id="columnSelector" class="dropdown">
     <mat-label>Select columns</mat-label>
     <mat-select multiple [(ngModel)]="displayedColumns">
-        <mat-option *ngFor="let columnName of checkboxLabels" [value]="columnName">
+        <mat-option *ngFor="let columnName of checkboxLabels" [value]="columnName" (click)="showCheckboxColumn()">
             {{ fixedColumnDescriptors(columnName) }}
         </mat-option>
     </mat-select>

--- a/projects/core/src/lib/datatable/table/table.component.html
+++ b/projects/core/src/lib/datatable/table/table.component.html
@@ -66,5 +66,12 @@
         </tr>
     </table>
 </div>
-
-<mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+<mat-form-field id="columnSelector" class="dropdown">
+    <mat-label>Select columns</mat-label>
+    <mat-select multiple [(ngModel)]="displayedColumns">
+        <mat-option *ngFor="let columnName of checkboxLabels" [value]="columnName">
+            {{ fixedColumnDescriptors(columnName) }}
+        </mat-option>
+    </mat-select>
+</mat-form-field>
+<mat-paginator class="paginate" [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>

--- a/projects/core/src/lib/datatable/table/table.component.html
+++ b/projects/core/src/lib/datatable/table/table.component.html
@@ -69,9 +69,9 @@
 <mat-form-field id="columnSelector" class="dropdown">
     <mat-label>Select columns</mat-label>
     <mat-select multiple [(ngModel)]="displayedColumns">
-        <mat-option *ngFor="let columnName of checkboxLabels" [value]="columnName" (click)="showCheckboxColumn()">
+        <mat-option *ngFor="let columnName of checkboxLabels" [value]="columnName" (click)="prependCheckboxColumn()">
             {{ fixedColumnDescriptors(columnName) }}
         </mat-option>
     </mat-select>
 </mat-form-field>
-<mat-paginator class="paginate" [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+<mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>

--- a/projects/core/src/lib/datatable/table/table.component.scss
+++ b/projects/core/src/lib/datatable/table/table.component.scss
@@ -40,7 +40,7 @@ table {
     color: var(--geoengine-foreground-secondary-text-color);
 }
 
-.paginate {
+.mat-paginator {
     float: right;
 }
 

--- a/projects/core/src/lib/datatable/table/table.component.scss
+++ b/projects/core/src/lib/datatable/table/table.component.scss
@@ -39,3 +39,11 @@ table {
     font-style: italic;
     color: var(--geoengine-foreground-secondary-text-color);
 }
+
+.paginate {
+    float: right;
+}
+
+.dropdown {
+    margin-left: 1rem;
+}

--- a/projects/core/src/lib/datatable/table/table.component.ts
+++ b/projects/core/src/lib/datatable/table/table.component.ts
@@ -133,6 +133,7 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         this.featureColumns = metadata.dataTypes.keySeq().toArray();
         this.featureColumnDataTypes = metadata.dataTypes.valueSeq().toArray();
         if (this.displayedColumns.length === 0) {
+            // Only true when the table is first created. Prevents "forgetting" selected columns when zooming/scrolling the map
             this.displayedColumns = ['_____select', '_____coordinates', '_____table__start', '_____table__end'].concat(this.featureColumns);
         }
         this.featureColumnDataTypes = this.getColumnProperties();
@@ -140,7 +141,10 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         setTimeout(() => this.navigatePage(this.projectService.getSelectedFeature()));
     }
 
-    showCheckboxColumn(): void {
+    /**
+     * Used by HTML template when (de)selecting a column to make sure the leftmost checkbox column stays visible
+     */
+    prependCheckboxColumn(): void {
         // Necessary because dropdown-menu is bound to displayedColumns. Since the menu doesn't contain an option for the
         // select-checkbox, that column gets removed on each change as well. It is added back in here.
         if (!this.displayedColumns.find((x) => x === '_____select')) {

--- a/projects/core/src/lib/datatable/table/table.component.ts
+++ b/projects/core/src/lib/datatable/table/table.component.ts
@@ -140,7 +140,7 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         setTimeout(() => this.navigatePage(this.projectService.getSelectedFeature()));
     }
 
-    showCheckboxColumn() {
+    showCheckboxColumn(): void {
         // Necessary because dropdown-menu is bound to displayedColumns. Since the menu doesn't contain an option for the
         // select-checkbox, that column gets removed on each change as well. It is added back in here.
         if (!this.displayedColumns.find((x) => x === '_____select')) {

--- a/projects/core/src/lib/datatable/table/table.component.ts
+++ b/projects/core/src/lib/datatable/table/table.component.ts
@@ -47,6 +47,7 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
     displayedColumns: Array<string> = [];
     featureColumns: Array<string> = [];
     featureColumnDataTypes: Array<VectorColumnDataType> = [];
+    checkboxLabels: Array<string> = [];
 
     protected layerDataSubscription?: Subscription = undefined;
     protected selectedFeatureSubscription?: Subscription = undefined;
@@ -78,6 +79,14 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
             } else {
                 this.emptyTable();
             }
+        }
+    }
+
+    ngDoCheck(): void {
+        // Necessary because dropdown-menu is bound to displayedColumns. Since the menu doesn't contain an option for the
+        // select-checkbox, that column gets removed on each change as well. It is added back in here.
+        if (!this.displayedColumns.find((x) => x === '_____select')) {
+            this.displayedColumns = this.displayedColumns.reverse().concat('_____select').reverse(); // Is there a better way to prepend?
         }
     }
 
@@ -133,7 +142,24 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         this.featureColumnDataTypes = metadata.dataTypes.valueSeq().toArray();
         this.displayedColumns = ['_____select', '_____coordinates', '_____table__start', '_____table__end'].concat(this.featureColumns);
         this.featureColumnDataTypes = this.getColumnProperties();
+        this.checkboxLabels = this.displayedColumns.filter((element) => element !== '_____select');
+        // this.checkboxLabels = this.displayedColumns; // TODO delete (only used when checkbox can be hidden)
         setTimeout(() => this.navigatePage(this.projectService.getSelectedFeature()));
+    }
+
+    /**
+     * Used only by HTML template to display prettier names for default columns inside dropdown menu
+     */
+    fixedColumnDescriptors(columnName: string): string {
+        return columnName === '_____coordinates'
+            ? 'Coordinates'
+            : columnName === '_____table__start'
+            ? 'Start '
+            : columnName === '_____table__end'
+            ? 'End'
+            : columnName === '_____select' // TODO delete this if hiding select box is not necessary
+            ? 'Select'
+            : columnName;
     }
 
     processRasterLayer(_layer: RasterLayer, _metadata: RasterLayerMetadata, _data: any): void {

--- a/projects/core/src/lib/datatable/table/table.component.ts
+++ b/projects/core/src/lib/datatable/table/table.component.ts
@@ -82,14 +82,6 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         }
     }
 
-    ngDoCheck(): void {
-        // Necessary because dropdown-menu is bound to displayedColumns. Since the menu doesn't contain an option for the
-        // select-checkbox, that column gets removed on each change as well. It is added back in here.
-        if (!this.displayedColumns.find((x) => x === '_____select')) {
-            this.displayedColumns = this.displayedColumns.reverse().concat('_____select').reverse(); // Is there a better way to prepend?
-        }
-    }
-
     ngAfterViewInit(): void {
         this.dataSource.paginator = this.paginator;
     }
@@ -147,6 +139,18 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         setTimeout(() => this.navigatePage(this.projectService.getSelectedFeature()));
     }
 
+    testClick() {
+        console.log('Test');
+    }
+
+    showCheckboxColumn() {
+        // Necessary because dropdown-menu is bound to displayedColumns. Since the menu doesn't contain an option for the
+        // select-checkbox, that column gets removed on each change as well. It is added back in here.
+        if (!this.displayedColumns.find((x) => x === '_____select')) {
+            this.displayedColumns = this.displayedColumns.reverse().concat('_____select').reverse(); // Is there a better way to prepend?
+        }
+    }
+
     /**
      * Used only by HTML template to display prettier names for default columns inside dropdown menu
      */
@@ -186,7 +190,11 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         // For truncated coordinate view in table
         const coords: string[][] = this.readCoordinates(geometry);
         const contd: string = coords[0].length > 1 ? '...' : '';
-        const output = ` ${coords[0][0]}, ${coords[1][0]} ${contd}`;
+        const displayLength = 5;
+        const output = ` ${this.sliceColumnContent(coords[0][0], displayLength)}, ${this.sliceColumnContent(
+            coords[1][0],
+            displayLength,
+        )} ${contd}`;
         return output;
     }
 

--- a/projects/core/src/lib/datatable/table/table.component.ts
+++ b/projects/core/src/lib/datatable/table/table.component.ts
@@ -132,22 +132,19 @@ export class DataTableComponent implements OnInit, AfterViewInit, OnDestroy, OnC
         this.dataSource.data = data.data;
         this.featureColumns = metadata.dataTypes.keySeq().toArray();
         this.featureColumnDataTypes = metadata.dataTypes.valueSeq().toArray();
-        this.displayedColumns = ['_____select', '_____coordinates', '_____table__start', '_____table__end'].concat(this.featureColumns);
+        if (this.displayedColumns.length === 0) {
+            this.displayedColumns = ['_____select', '_____coordinates', '_____table__start', '_____table__end'].concat(this.featureColumns);
+        }
         this.featureColumnDataTypes = this.getColumnProperties();
-        this.checkboxLabels = this.displayedColumns.filter((element) => element !== '_____select');
-        // this.checkboxLabels = this.displayedColumns; // TODO delete (only used when checkbox can be hidden)
+        this.checkboxLabels = ['_____coordinates', '_____table__start', '_____table__end'].concat(this.featureColumns);
         setTimeout(() => this.navigatePage(this.projectService.getSelectedFeature()));
-    }
-
-    testClick() {
-        console.log('Test');
     }
 
     showCheckboxColumn() {
         // Necessary because dropdown-menu is bound to displayedColumns. Since the menu doesn't contain an option for the
         // select-checkbox, that column gets removed on each change as well. It is added back in here.
         if (!this.displayedColumns.find((x) => x === '_____select')) {
-            this.displayedColumns = this.displayedColumns.reverse().concat('_____select').reverse(); // Is there a better way to prepend?
+            this.displayedColumns = ['_____select'].concat(this.displayedColumns);
         }
     }
 


### PR DESCRIPTION
When displaying the datatable, a dropdown menu allows for hiding/revealing individual columns
<img width="496" alt="image" src="https://user-images.githubusercontent.com/57327151/195652340-37e63782-c7e3-45d8-abac-03a0b2b17fa6.png">
Selections persist when moving/zooming the map, but not when switching to a different layer/datatable, since the table component is recreated in this case.

(Also, coordinate preview in the table is cut off after 5 places (including dot), full display available via button)
<img width="146" alt="image" src="https://user-images.githubusercontent.com/57327151/195659047-59fbc63e-0f5f-453d-8e47-dc6a61f539db.png">
