### PR TITLE
Symbology Editor - Global Layer Properties: Apply color changes manually

### DIFF
--- a/projects/core/src/lib/colors/color-map-selector/color-map-selector.component.html
+++ b/projects/core/src/lib/colors/color-map-selector/color-map-selector.component.html
@@ -72,8 +72,6 @@
             </table>
         </div>
 
-        <!-- <mat-action-row>
-            <button type="submit" mat-raised-button color="primary" [disabled]="form.invalid">Create color table</button>
-        </mat-action-row> -->
+        <!-- TODO: will be instantiated to populate the color table -->
     </form>
 </div>

--- a/projects/core/src/lib/colors/color-map-selector/color-map-selector.component.html
+++ b/projects/core/src/lib/colors/color-map-selector/color-map-selector.component.html
@@ -72,6 +72,9 @@
             </table>
         </div>
 
-        <!-- TODO: will be instantiated to populate the color table -->
+        <!-- TODO: This will be instantiated to populate the color table -->
+        <!-- <mat-action-row>
+            <button type="submit" mat-raised-button color="primary" [disabled]="form.invalid">Create color table</button>
+        </mat-action-row> -->
     </form>
 </div>

--- a/projects/core/src/lib/colors/color-map-selector/color-map-selector.component.html
+++ b/projects/core/src/lib/colors/color-map-selector/color-map-selector.component.html
@@ -1,5 +1,5 @@
 <div class="component_container">
-    <form [formGroup]="form" (ngSubmit)="applyNewColorTable($event)" fxLayout="column">
+    <form [formGroup]="form" (ngSubmit)="applyChanges()" fxLayout="column">
         <div
             formGroupName="bounds"
             class="flex-container"
@@ -72,8 +72,8 @@
             </table>
         </div>
 
-        <mat-action-row>
+        <!-- <mat-action-row>
             <button type="submit" mat-raised-button color="primary" [disabled]="form.invalid">Create color table</button>
-        </mat-action-row>
+        </mat-action-row> -->
     </form>
 </div>

--- a/projects/core/src/lib/colors/color-map-selector/color-map-selector.component.ts
+++ b/projects/core/src/lib/colors/color-map-selector/color-map-selector.component.ts
@@ -33,6 +33,11 @@ export class ColorMapSelectorComponent implements OnInit, OnDestroy, OnChanges {
     @Output() breakpointsChange = new EventEmitter<Array<ColorBreakpoint>>();
 
     /**
+     * Informs parent to enable "Apply Changes" button
+     */
+    @Output() changesToForm = new EventEmitter<void>();
+
+    /**
      * Number of breakpoints used in the ColorizerData.
      */
     @Input() defaultNumberOfSteps = 16;
@@ -125,6 +130,10 @@ export class ColorMapSelectorComponent implements OnInit, OnDestroy, OnChanges {
             }
         });
         this.subscriptions.push(subMinMax);
+
+        this.form.valueChanges.subscribe(() => {
+            this.changesToForm.emit();
+        });
     }
 
     ngOnDestroy(): void {
@@ -184,9 +193,9 @@ export class ColorMapSelectorComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     /**
-     * Apply a new color table to the colorizer data.
+     * Apply changes to color table to the colorizer data.
      */
-    applyNewColorTable(_: any): void {
+    applyChanges(): void {
         if (!this.breakpoints) {
             return;
         }

--- a/projects/core/src/lib/datasets/add-data/add-data.component.ts
+++ b/projects/core/src/lib/datasets/add-data/add-data.component.ts
@@ -71,7 +71,7 @@ export class AddDataComponent implements OnInit {
     static createUploadButton(): AddDataButton {
         return {
             name: 'Upload',
-            description: 'Upload data from you local computer',
+            description: 'Upload data from your local computer',
             icon: 'publish',
             sidenavConfig: {component: UploadComponent, keepParent: true},
         };

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -93,7 +93,7 @@
                 </ng-template>
             </mat-expansion-panel>
 
-            <mat-expansion-panel *ngIf="getColorizerType() !== 'palette'" expanded="true">
+            <mat-expansion-panel *ngIf="paletteSelected === false" expanded="true">
                 <mat-expansion-panel-header>
                     <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
                         <mat-icon>looks</mat-icon>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -136,7 +136,6 @@
                     </mat-panel-title>
                 </mat-expansion-panel-header>
                 <ng-template matExpansionPanelContent>
-                    <!-- <geoengine-colorizer-editor [ngModel]="symbology.colorizer" (ngModelChange)="updateColorizer($event)"></geoengine-colorizer-editor> -->
                 </ng-template>
             </mat-expansion-panel>
         </mat-accordion>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -79,11 +79,10 @@
                             [multiple]="false"
                             [ngModel]="getColorizerType()"
                             (ngModelChange)="updateColorizerType($event)"
-                            [disabled]="getColorizerType() === 'palette'"
                         >
                             <mat-button-toggle fxFlexFill value="linearGradient">Linear Gradient</mat-button-toggle>
                             <mat-button-toggle fxFlexFill value="logarithmicGradient">Logarithmic Gradient</mat-button-toggle>
-                            <mat-button-toggle fxFlexFill value="palette" [disabled]="true">Palette</mat-button-toggle>
+                            <mat-button-toggle fxFlexFill value="palette">Palette</mat-button-toggle>
                         </mat-button-toggle-group>
                     </p>
                     <div
@@ -94,7 +93,7 @@
                 </ng-template>
             </mat-expansion-panel>
 
-            <mat-expansion-panel expanded="true">
+            <mat-expansion-panel *ngIf="getColorizerType() !== 'palette'" expanded="true">
                 <mat-expansion-panel-header>
                     <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
                         <mat-icon>looks</mat-icon>
@@ -113,7 +112,7 @@
                         <mat-progress-bar mode="indeterminate" *ngIf="histogramLoading | async"></mat-progress-bar>
                     </div>
                     <div class="actions">
-                        <button mat-raised-button class="button" color="primary" (click)="updateHistogram()">Update Histogram</button>
+                        <button mat-raised-button class="button" color="primary" (click)="updateHistogram()">Calculate Histogram</button>
                     </div>
                     <mat-divider></mat-divider>
 
@@ -144,12 +143,12 @@
     </div>
 
     <div class="actions">
-        <button mat-raised-button color="primary" class="button" (click)="applyChanges()" [disabled]="unappliedChanges === false">
-            Apply
-        </button>
-
         <button mat-raised-button color="accent" class="button" (click)="resetChanges(layer)" [disabled]="unappliedChanges === false">
             Reset
+        </button>
+
+        <button mat-raised-button color="primary" class="button" (click)="applyChanges()" [disabled]="unappliedChanges === false">
+            Apply
         </button>
     </div>
 </div>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -145,6 +145,7 @@
     </div>
 
     <div class="actions">
+        <span class="hint" *ngIf="unappliedChanges === true">Changes not reflected in map view!</span>
         <button mat-raised-button color="primary" id="applyButton" (click)="applyChanges()" [disabled]="unappliedChanges === false">
             Apply changes
         </button>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -1,133 +1,152 @@
 <geoengine-sidenav-header>Symbology Editor</geoengine-sidenav-header>
 
-<geoengine-dialog-help>
-    <p>The Symbology Editor enables customization of the style for raster layers.</p>
-    <p>
-        The <i>Global Layer Properties</i> define the default visualization parameters. The layer <i>Opacity</i> is adjustable in a range
-        from 0 to 100 %. You can choose a <i>NoData</i> color for pixels with the nodata value. Use the picker tool to select the desired
-        RGB color and opacity. This also applies to the <i>Overflow</i> color, which indicates the pixels with values without coloring
-        rules.
-    </p>
-    <p>
-        The <i>Color Map</i> section provides an overview of the pixel values with a frequency plot, which also allows to adapt the color
-        with respect to the raster values. The plot refers to the field of view shown in the map. If <i>Sync map and histogram </i> is
-        turned on, the histogram updates if the map view changes. To specify the value range of interest, you can set a minimum and maximum
-        pixel value. You can choose a color ramp from a variety of color schemes (<i>Colormap name</i>) and reverse it, if desired.
-        Additionally, different functions for the step distribution can be selected (linear, logarithmic, square root function, square
-        function). Consider that the logarithmic function requires positive values (>0). The number of Color steps is also kept flexible and
-        can be set to a number between 2 and 16. Click <i>Create color table</i> to apply your adjustments.
-    </p>
-    <p>
-        The <i> Color Table section </i> allows fine grained changes to colors. The gradient defines the interpolation between values. You
-        can dynamically add and remove color steps by clicking the minus and plus symbols or select distinct RGBA values for a specific
-        color step value.
-    </p>
-</geoengine-dialog-help>
-
-<mat-accordion multi="true">
-    <mat-expansion-panel expanded="true">
-        <mat-expansion-panel-header>
-            <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
-                <mat-icon>map</mat-icon>
-                <span fxFlex>Global Layer Properties</span>
-            </mat-panel-title>
-        </mat-expansion-panel-header>
-        <ng-template matExpansionPanelContent>
-            <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
-                <span>Opacity</span>
-                <mat-slider fxFlex #slo (change)="updateOpacity($event)" [value]="getOpacity()" max="100" min="1" step="1" thumbLabel>
-                </mat-slider>
-                <span>{{ slo.displayValue }} %</span>
-            </div>
-            <mat-divider></mat-divider>
-            <div>
-                <geoengine-color-attribute-input
-                    [ngModel]="getNoDataColor()"
-                    (ngModelChange)="updateNoDataColor($event)"
-                    attributePlaceholder=""
-                    [readonlyAttribute]="true"
-                >
-                </geoengine-color-attribute-input>
-                <geoengine-color-attribute-input
-                    [ngModel]="getDefaultColor()"
-                    (ngModelChange)="updateDefaultColor($event)"
-                    attributePlaceholder=""
-                    [readonlyAttribute]="true"
-                >
-                </geoengine-color-attribute-input>
-            </div>
-
-            <p fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
-                <span>Colorizer:</span>
-                <mat-button-toggle-group
-                    id="gradientType"
-                    fxFlex
-                    [multiple]="false"
-                    [ngModel]="getColorizerType()"
-                    (ngModelChange)="updateColorizerType($event)"
-                    [disabled]="getColorizerType() === 'palette'"
-                >
-                    <mat-button-toggle fxFlex value="linearGradient">Linear Gradient</mat-button-toggle>
-                    <mat-button-toggle fxFlex value="logarithmicGradient">Logarithmic Gradient</mat-button-toggle>
-                    <mat-button-toggle fxFlex value="palette" [disabled]="true">Palette</mat-button-toggle>
-                </mat-button-toggle-group>
+<div class="outer" fxLayout="column">
+    <div fxFlex class="container">
+        <geoengine-dialog-help>
+            <p>The Symbology Editor enables customization of the style for raster layers.</p>
+            <p>
+                The <i>Global Layer Properties</i> define the default visualization parameters. The layer <i>Opacity</i> is adjustable in a
+                range from 0 to 100 %. You can choose a <i>NoData</i> color for pixels with the nodata value. Use the picker tool to select
+                the desired RGB color and opacity. This also applies to the <i>Overflow</i> color, which indicates the pixels with values
+                without coloring rules.
             </p>
-            <button mat-raised-button color="primary" id="applyButton" (click)="applyChanges()" [disabled]="unappliedChanges === false">
-                Apply changes
-            </button>
-            <div
-                *ngIf="symbology.colorizer.isGradient()"
-                class="colorizer-preview"
-                [style.background]="symbology.colorizer | geoengineColorizerCssGradient: 90"
-            ></div>
-        </ng-template>
-    </mat-expansion-panel>
+            <p>
+                The <i>Color Map</i> section provides an overview of the pixel values with a frequency plot, which also allows to adapt the
+                color with respect to the raster values. The plot refers to the field of view shown in the map. If
+                <i>Sync map and histogram </i> is turned on, the histogram updates if the map view changes. To specify the value range of
+                interest, you can set a minimum and maximum pixel value. You can choose a color ramp from a variety of color schemes (<i
+                    >Colormap name</i
+                >) and reverse it, if desired. Additionally, different functions for the step distribution can be selected (linear,
+                logarithmic, square root function, square function). Consider that the logarithmic function requires positive values (>0).
+                The number of Color steps is also kept flexible and can be set to a number between 2 and 16. Click
+                <i>Create color table</i> to apply your adjustments.
+            </p>
+            <p>
+                The <i> Color Table section </i> allows fine grained changes to colors. The gradient defines the interpolation between
+                values. You can dynamically add and remove color steps by clicking the minus and plus symbols or select distinct RGBA values
+                for a specific color step value.
+            </p>
+        </geoengine-dialog-help>
 
-    <mat-expansion-panel expanded="true">
-        <mat-expansion-panel-header>
-            <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
-                <mat-icon>looks</mat-icon>
-                <span fxFlex>Update Color Map</span>
-            </mat-panel-title>
-        </mat-expansion-panel-header>
+        <mat-accordion multi="true">
+            <mat-expansion-panel expanded="true">
+                <mat-expansion-panel-header>
+                    <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
+                        <mat-icon>map</mat-icon>
+                        <span fxFlex>Global Layer Properties</span>
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
+                <ng-template matExpansionPanelContent>
+                    <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
+                        <span>Opacity</span>
+                        <mat-slider
+                            fxFlex
+                            #slo
+                            (change)="updateOpacity($event)"
+                            [value]="getOpacity()"
+                            max="100"
+                            min="1"
+                            step="1"
+                            thumbLabel
+                        >
+                        </mat-slider>
+                        <span>{{ slo.displayValue }} %</span>
+                    </div>
+                    <mat-divider></mat-divider>
+                    <div>
+                        <geoengine-color-attribute-input
+                            [ngModel]="getNoDataColor()"
+                            (ngModelChange)="updateNoDataColor($event)"
+                            attributePlaceholder=""
+                            [readonlyAttribute]="true"
+                        >
+                        </geoengine-color-attribute-input>
+                        <geoengine-color-attribute-input
+                            [ngModel]="getDefaultColor()"
+                            (ngModelChange)="updateDefaultColor($event)"
+                            attributePlaceholder=""
+                            [readonlyAttribute]="true"
+                        >
+                        </geoengine-color-attribute-input>
+                    </div>
 
-        <ng-template matExpansionPanelContent>
-            <div class="histogram">
-                <ng-container *ngIf="histogramData | async as histogramData">
-                    <geoengine-vega-viewer
-                        [chartData]="histogramData"
-                        (interactionChange)="updateBounds($any($event))"
-                    ></geoengine-vega-viewer>
-                </ng-container>
-                <mat-progress-bar mode="indeterminate" *ngIf="histogramLoading | async"></mat-progress-bar>
-            </div>
-            <div>
-                <mat-slide-toggle [checked]="histogramAutoReload" (change)="histogramAutoReload = $event.checked">
-                    Sync map and histogram
-                </mat-slide-toggle>
-            </div>
-            <mat-divider></mat-divider>
+                    <p fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
+                        <span>Colorizer:</span>
+                        <mat-button-toggle-group
+                            id="gradientType"
+                            fxFlex
+                            [multiple]="false"
+                            [ngModel]="getColorizerType()"
+                            (ngModelChange)="updateColorizerType($event)"
+                            [disabled]="getColorizerType() === 'palette'"
+                        >
+                            <mat-button-toggle fxFlex value="linearGradient">Linear Gradient</mat-button-toggle>
+                            <mat-button-toggle fxFlex value="logarithmicGradient">Logarithmic Gradient</mat-button-toggle>
+                            <mat-button-toggle fxFlex value="palette" [disabled]="true">Palette</mat-button-toggle>
+                        </mat-button-toggle-group>
+                    </p>
+                    <div
+                        *ngIf="symbology.colorizer.isGradient()"
+                        class="colorizer-preview"
+                        [style.background]="symbology.colorizer | geoengineColorizerCssGradient: 90"
+                    ></div>
+                </ng-template>
+            </mat-expansion-panel>
 
-            <geoengine-color-map-selector
-                (breakpointsChange)="updateBreakpoints($event)"
-                [minValue]="layerMinValue"
-                [maxValue]="layerMaxValue"
-                [scale]="scale"
-            >
-            </geoengine-color-map-selector>
-        </ng-template>
-    </mat-expansion-panel>
+            <mat-expansion-panel expanded="true">
+                <mat-expansion-panel-header>
+                    <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
+                        <mat-icon>looks</mat-icon>
+                        <span fxFlex>Update Color Map</span>
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
 
-    <!-- TODO: implement palette editor -->
-    <mat-expansion-panel expanded="false" *ngIf="symbology.colorizer.isDiscrete()">
-        <mat-expansion-panel-header>
-            <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
-                <mat-icon>color_lens</mat-icon>
-                <span fxFlex>Color Table</span>
-            </mat-panel-title>
-        </mat-expansion-panel-header>
-        <ng-template matExpansionPanelContent>
-            <!-- <geoengine-colorizer-editor [ngModel]="symbology.colorizer" (ngModelChange)="updateColorizer($event)"></geoengine-colorizer-editor> -->
-        </ng-template>
-    </mat-expansion-panel>
-</mat-accordion>
+                <ng-template matExpansionPanelContent>
+                    <div class="histogram">
+                        <ng-container *ngIf="histogramData | async as histogramData">
+                            <geoengine-vega-viewer
+                                [chartData]="histogramData"
+                                (interactionChange)="updateBounds($any($event))"
+                            ></geoengine-vega-viewer>
+                        </ng-container>
+                        <mat-progress-bar mode="indeterminate" *ngIf="histogramLoading | async"></mat-progress-bar>
+                    </div>
+                    <div>
+                        <mat-slide-toggle [checked]="histogramAutoReload" (change)="histogramAutoReload = $event.checked">
+                            Sync map and histogram
+                        </mat-slide-toggle>
+                    </div>
+                    <mat-divider></mat-divider>
+
+                    <geoengine-color-map-selector
+                        (breakpointsChange)="updateBreakpoints($event)"
+                        (changesToForm)="getNotified()"
+                        [minValue]="layerMinValue"
+                        [maxValue]="layerMaxValue"
+                        [scale]="scale"
+                    >
+                    </geoengine-color-map-selector>
+                </ng-template>
+            </mat-expansion-panel>
+
+            <!-- TODO: implement palette editor -->
+            <mat-expansion-panel expanded="false" *ngIf="symbology.colorizer.isDiscrete()">
+                <mat-expansion-panel-header>
+                    <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
+                        <mat-icon>color_lens</mat-icon>
+                        <span fxFlex>Color Table</span>
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
+                <ng-template matExpansionPanelContent>
+                    <!-- <geoengine-colorizer-editor [ngModel]="symbology.colorizer" (ngModelChange)="updateColorizer($event)"></geoengine-colorizer-editor> -->
+                </ng-template>
+            </mat-expansion-panel>
+        </mat-accordion>
+    </div>
+
+    <div class="actions">
+        <button mat-raised-button color="primary" id="applyButton" (click)="applyChanges()" [disabled]="unappliedChanges === false">
+            Apply changes
+        </button>
+    </div>
+</div>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -25,11 +25,11 @@
 </geoengine-dialog-help>
 
 <mat-accordion multi="true">
-    <mat-expansion-panel expanded="true" [class]="unappliedChanges ? 'attention' : 'default'">
+    <mat-expansion-panel expanded="true">
         <mat-expansion-panel-header>
             <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
                 <mat-icon>map</mat-icon>
-                <span fxFlex>Global Layer Properties</span><span *ngIf="unappliedChanges === true">(Unapplied Changes)</span>
+                <span fxFlex>Global Layer Properties</span>
             </mat-panel-title>
         </mat-expansion-panel-header>
         <ng-template matExpansionPanelContent>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -70,8 +70,9 @@
                         </geoengine-color-attribute-input>
                     </div>
 
+                    <mat-divider></mat-divider>
+                    <span>Colorizer:</span>
                     <p fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
-                        <span>Colorizer:</span>
                         <mat-button-toggle-group
                             id="gradientType"
                             fxFlex
@@ -80,9 +81,9 @@
                             (ngModelChange)="updateColorizerType($event)"
                             [disabled]="getColorizerType() === 'palette'"
                         >
-                            <mat-button-toggle fxFlex value="linearGradient">Linear Gradient</mat-button-toggle>
-                            <mat-button-toggle fxFlex value="logarithmicGradient">Logarithmic Gradient</mat-button-toggle>
-                            <mat-button-toggle fxFlex value="palette" [disabled]="true">Palette</mat-button-toggle>
+                            <mat-button-toggle fxFlexFill value="linearGradient">Linear Gradient</mat-button-toggle>
+                            <mat-button-toggle fxFlexFill value="logarithmicGradient">Logarithmic Gradient</mat-button-toggle>
+                            <mat-button-toggle fxFlexFill value="palette" [disabled]="true">Palette</mat-button-toggle>
                         </mat-button-toggle-group>
                     </p>
                     <div
@@ -111,10 +112,8 @@
                         </ng-container>
                         <mat-progress-bar mode="indeterminate" *ngIf="histogramLoading | async"></mat-progress-bar>
                     </div>
-                    <div>
-                        <mat-slide-toggle [checked]="histogramAutoReload" (change)="histogramAutoReload = $event.checked">
-                            Sync map and histogram
-                        </mat-slide-toggle>
+                    <div class="actions">
+                        <button mat-raised-button class="button" color="primary" (click)="updateHistogram()">Update Histogram</button>
                     </div>
                     <mat-divider></mat-divider>
 
@@ -145,9 +144,12 @@
     </div>
 
     <div class="actions">
-        <span class="hint" *ngIf="unappliedChanges === true">Changes not reflected in map view!</span>
-        <button mat-raised-button color="primary" id="applyButton" (click)="applyChanges()" [disabled]="unappliedChanges === false">
-            Apply changes
+        <button mat-raised-button color="primary" class="button" (click)="applyChanges()" [disabled]="unappliedChanges === false">
+            Apply
+        </button>
+
+        <button mat-raised-button color="accent" class="button" (click)="resetChanges(layer)" [disabled]="unappliedChanges === false">
+            Reset
         </button>
     </div>
 </div>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -29,7 +29,7 @@
         <mat-expansion-panel-header>
             <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
                 <mat-icon>map</mat-icon>
-                <span fxFlex>Global Layer Properties</span><span *ngIf="unappliedChanges === true">(unapplied Changes)</span>
+                <span fxFlex>Global Layer Properties</span><span *ngIf="unappliedChanges === true">(Unapplied Changes)</span>
             </mat-panel-title>
         </mat-expansion-panel-header>
         <ng-template matExpansionPanelContent>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -135,8 +135,7 @@
                         <span fxFlex>Color Table</span>
                     </mat-panel-title>
                 </mat-expansion-panel-header>
-                <ng-template matExpansionPanelContent>
-                </ng-template>
+                <ng-template matExpansionPanelContent> </ng-template>
             </mat-expansion-panel>
         </mat-accordion>
     </div>

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -111,17 +111,16 @@
                         </ng-container>
                         <mat-progress-bar mode="indeterminate" *ngIf="histogramLoading | async"></mat-progress-bar>
                     </div>
-                    <div class="actions" *ngIf="histogramCreated; then createdBlock; else notCreatedBlock"></div>
-                    <!-- Only displayed before any histogram is created -->
-                    <ng-template #createdBlock>
-                        <div class="actions">
-                            <button mat-raised-button class="button" color="primary" (click)="updateHistogram()">Update Histogram</button>
-                        </div>
-                    </ng-template>
-                    <!-- Only displayed after histogram is created -->
-                    <ng-template #notCreatedBlock>
-                        <button mat-raised-button class="button" color="primary" (click)="updateHistogram()">Create Histogram</button>
-                    </ng-template>
+                    <div class="histogram-actions">
+                        <button mat-stroked-button class="button" (click)="updateHistogram()">
+                            <ng-container *ngIf="histogramCreated; then createdBlock; else notCreatedBlock"></ng-container>
+                            <!-- Only displayed before any histogram is created -->
+                            <ng-template #createdBlock>Update Histogram</ng-template>
+                            <!-- Only displayed after histogram is created -->
+                            <ng-template #notCreatedBlock>Create Histogram</ng-template>
+                        </button>
+                    </div>
+
                     <mat-divider></mat-divider>
 
                     <geoengine-color-map-selector
@@ -149,9 +148,7 @@
     </div>
 
     <div class="actions">
-        <button mat-raised-button color="accent" class="button" (click)="resetChanges(layer)" [disabled]="unappliedChanges === false">
-            Reset
-        </button>
+        <button mat-raised-button class="button" (click)="resetChanges(layer)" [disabled]="unappliedChanges === false">Reset</button>
 
         <button mat-raised-button color="primary" class="button" (click)="applyChanges()" [disabled]="unappliedChanges === false">
             Apply

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -102,7 +102,7 @@
                 </mat-expansion-panel-header>
 
                 <ng-template matExpansionPanelContent>
-                    <div class="histogram">
+                    <div class="histogram" *ngIf="histogramCreated === true">
                         <ng-container *ngIf="histogramData | async as histogramData">
                             <geoengine-vega-viewer
                                 [chartData]="histogramData"
@@ -111,9 +111,17 @@
                         </ng-container>
                         <mat-progress-bar mode="indeterminate" *ngIf="histogramLoading | async"></mat-progress-bar>
                     </div>
-                    <div class="actions">
-                        <button mat-raised-button class="button" color="primary" (click)="updateHistogram()">Calculate Histogram</button>
-                    </div>
+                    <div class="actions" *ngIf="histogramCreated; then createdBlock; else notCreatedBlock"></div>
+                    <!-- Only displayed before any histogram is created -->
+                    <ng-template #createdBlock>
+                        <div class="actions">
+                            <button mat-raised-button class="button" color="primary" (click)="updateHistogram()">Update Histogram</button>
+                        </div>
+                    </ng-template>
+                    <!-- Only displayed after histogram is created -->
+                    <ng-template #notCreatedBlock>
+                        <button mat-raised-button class="button" color="primary" (click)="updateHistogram()">Create Histogram</button>
+                    </ng-template>
                     <mat-divider></mat-divider>
 
                     <geoengine-color-map-selector

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.html
@@ -25,11 +25,11 @@
 </geoengine-dialog-help>
 
 <mat-accordion multi="true">
-    <mat-expansion-panel expanded="true">
+    <mat-expansion-panel expanded="true" [class]="unappliedChanges ? 'attention' : 'default'">
         <mat-expansion-panel-header>
             <mat-panel-title fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
                 <mat-icon>map</mat-icon>
-                <span fxFlex>Global Layer Properties</span>
+                <span fxFlex>Global Layer Properties</span><span *ngIf="unappliedChanges === true">(unapplied Changes)</span>
             </mat-panel-title>
         </mat-expansion-panel-header>
         <ng-template matExpansionPanelContent>
@@ -60,6 +60,7 @@
             <p fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="0.5rem">
                 <span>Colorizer:</span>
                 <mat-button-toggle-group
+                    id="gradientType"
                     fxFlex
                     [multiple]="false"
                     [ngModel]="getColorizerType()"
@@ -71,6 +72,9 @@
                     <mat-button-toggle fxFlex value="palette" [disabled]="true">Palette</mat-button-toggle>
                 </mat-button-toggle-group>
             </p>
+            <button mat-raised-button color="primary" id="applyButton" (click)="applyChanges()" [disabled]="unappliedChanges === false">
+                Apply changes
+            </button>
             <div
                 *ngIf="symbology.colorizer.isGradient()"
                 class="colorizer-preview"

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
@@ -24,3 +24,17 @@ mat-slider {
         margin: 0 auto;
     }
 }
+
+#applyButton {
+    margin-right: 0rem;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+
+.attention {
+    background-color: #ffeeee;
+}
+
+#gradientType {
+    flex-wrap: wrap;
+}

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
@@ -1,8 +1,3 @@
-:host {
-    display: block;
-    padding: 1rem;
-}
-
 mat-divider {
     padding-bottom: 1rem;
 }
@@ -25,12 +20,23 @@ mat-slider {
     }
 }
 
-#applyButton {
-    margin-right: 0rem;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-}
-
 #gradientType {
     flex-wrap: wrap;
+}
+
+.outer {
+    height: 100%;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.container {
+    overflow-y: auto;
+    padding: 0rem 1rem 1rem 1rem;
+}
+
+.actions {
+    text-align: right;
+    height: 3rem;
+    padding: 1rem;
 }

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
@@ -40,3 +40,8 @@ mat-slider {
     height: 3rem;
     padding: 1rem;
 }
+
+.hint {
+    text-align: left;
+    padding: 1rem;
+}

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
@@ -31,10 +31,6 @@ mat-slider {
     margin-bottom: 1rem;
 }
 
-.attention {
-    background-color: #ffeeee;
-}
-
 #gradientType {
     flex-wrap: wrap;
 }

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
@@ -20,6 +20,10 @@ mat-slider {
     }
 }
 
+.histogram-actions {
+    text-align: center;
+}
+
 #gradientType {
     flex-wrap: wrap;
 }

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.scss
@@ -45,3 +45,7 @@ mat-slider {
     text-align: left;
     padding: 1rem;
 }
+
+.button {
+    margin: 0.5rem;
+}

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -58,6 +58,9 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
 
     histogramData = new ReplaySubject<VegaChartData>(1);
     histogramLoading = new BehaviorSubject(false);
+
+    paletteSelected = false; // TODO: Remove once color palette picker is implemented and switch to "getColorizerType()"
+
     protected histogramWorkflowId = new ReplaySubject<UUID>(1);
     protected histogramSubscription?: Subscription;
 
@@ -249,11 +252,13 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
 
     updateColorizerType(colorizerType: 'linearGradient' | 'logarithmicGradient' | 'palette'): void {
         if (this.getColorizerType() === colorizerType) {
+            this.paletteSelected = false;
             return;
         }
 
         if (colorizerType === 'palette' || this.getColorizerType() === 'palette') {
             // TODO: implement palette
+            this.paletteSelected = true;
             return;
         }
 
@@ -261,6 +266,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
             const breakpoints = this.symbology.colorizer.getBreakpoints();
             let noDataColor: Color;
             let defaultColor: Color;
+            this.paletteSelected = false;
 
             if (this.symbology.colorizer instanceof LogarithmicGradient) {
                 noDataColor = this.symbology.colorizer.noDataColor;
@@ -276,6 +282,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
             const breakpoints = this.symbology.colorizer.getBreakpoints();
             let noDataColor: Color;
             let defaultColor: Color;
+            this.paletteSelected = false;
 
             if (this.symbology.colorizer instanceof LinearGradient) {
                 noDataColor = this.symbology.colorizer.noDataColor;
@@ -289,6 +296,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
             this.symbology = this.symbology.cloneWith({colorizer});
         } else if (colorizerType === 'palette') {
             // TODO: implement palette
+            this.paletteSelected = true;
             return;
         }
 

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -39,6 +39,8 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
 
     scale: 'linear' | 'logarithmic' = 'linear';
 
+    unappliedChanges: boolean = false;
+
     histogramData = new ReplaySubject<VegaChartData>(1);
     histogramLoading = new BehaviorSubject(false);
     protected histogramWorkflowId = new ReplaySubject<UUID>(1);
@@ -138,7 +140,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
 
         this.symbology = this.symbology.cloneWith({opacity});
 
-        this.update();
+        this.unappliedChanges = true;
     }
 
     getDefaultColor(): ColorAttributeInput {
@@ -162,6 +164,11 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
             throw new Error('unsupported colorizer type');
         }
 
+        this.unappliedChanges = true;
+    }
+
+    applyChanges(): void {
+        this.unappliedChanges = false;
         this.update();
     }
 
@@ -189,7 +196,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
             throw new Error('unsupported colorizer type');
         }
 
-        this.update();
+        this.unappliedChanges = true;
     }
 
     getColorizerType(): 'linearGradient' | 'logarithmicGradient' | 'palette' {
@@ -263,7 +270,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
         }
 
         this.updateScale();
-        this.update();
+        this.unappliedChanges = true;
     }
 
     /**

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -58,6 +58,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
 
     histogramData = new ReplaySubject<VegaChartData>(1);
     histogramLoading = new BehaviorSubject(false);
+    histogramCreated = false;
 
     paletteSelected = false; // TODO: Remove once color palette picker is implemented and switch to "getColorizerType()"
 
@@ -345,6 +346,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
     }
 
     updateHistogram(): void {
+        this.histogramCreated = true;
         this.histogramSubscription = this.createHistogramStream().subscribe((histogramData) => {
             this.histogramData.next(histogramData);
             this.histogramSubscription?.unsubscribe();

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -85,9 +85,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
         this.createHistogramWorkflowId().subscribe((histogramWorkflowId) => this.histogramWorkflowId.next(histogramWorkflowId));
     }
 
-    ngAfterViewInit(): void {
-        this.updateHistogram();
-    }
+    ngAfterViewInit(): void {}
 
     ngOnDestroy(): void {
         if (this.histogramSubscription) {

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -86,6 +86,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
         this.updateLayerMinMaxFromColorizer();
 
         this.createHistogramWorkflowId().subscribe((histogramWorkflowId) => this.histogramWorkflowId.next(histogramWorkflowId));
+        this.updateColorizerType(this.getColorizerType()); // TODO: Remove after palettes are implemented
     }
 
     ngAfterViewInit(): void {}

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -339,6 +339,14 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
         this.updateLayerMaxValue(breakpoints[breakpoints.length - 1].value);
     }
 
+    updateHistogram(): void {
+        this.histogramSubscription = this.createHistogramStream().subscribe((histogramData) => {
+            this.histogramData.next(histogramData);
+            this.histogramSubscription?.unsubscribe();
+            this.histogramAutoReload = false;
+        });
+    }
+
     private updateNodataAndDefaultColor(): void {
         this.defaultColor = {
             key: 'Overflow Color',
@@ -368,14 +376,6 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
         }
 
         this.histogramSubscription = this.createHistogramStream().subscribe((histogramData) => this.histogramData.next(histogramData));
-    }
-
-    updateHistogram(): void {
-        this.histogramSubscription = this.createHistogramStream().subscribe((histogramData) => {
-            this.histogramData.next(histogramData);
-            this.histogramSubscription?.unsubscribe();
-            this.histogramAutoReload = false;
-        });
     }
 
     private createHistogramStream(): Observable<VegaChartData> {

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -197,7 +197,10 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
     }
 
     resetChanges(layer: Layer): void {
-        this.layoutService.setSidenavContentComponent({component: RasterSymbologyEditorComponent, config: {layer}});
+        this.layoutService.setSidenavContentComponent({
+            component: RasterSymbologyEditorComponent,
+            config: {layer, histogramData: this.histogramData, histogramCreated: this.histogramCreated},
+        });
     }
 
     getNoDataColor(): ColorAttributeInput {

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -1,4 +1,14 @@
-import {Component, Input, ChangeDetectionStrategy, OnChanges, SimpleChanges, OnDestroy, AfterViewInit, OnInit} from '@angular/core';
+import {
+    Component,
+    Input,
+    ChangeDetectionStrategy,
+    OnChanges,
+    SimpleChanges,
+    OnDestroy,
+    AfterViewInit,
+    OnInit,
+    ViewChild,
+} from '@angular/core';
 import {BehaviorSubject, combineLatest, Observable, of, ReplaySubject, Subscription} from 'rxjs';
 import {map, mergeMap, tap} from 'rxjs/operators';
 import {RasterSymbology} from '../symbology.model';
@@ -17,6 +27,7 @@ import {UserService} from '../../../users/user.service';
 import {extentToBboxDict} from '../../../util/conversions';
 import {VegaChartData} from '../../../plots/vega-viewer/vega-viewer.component';
 import {Color} from '../../../colors/color';
+import {ColorMapSelectorComponent} from '../../../colors/color-map-selector/color-map-selector.component';
 
 /**
  * An editor for generating raster symbologies.
@@ -28,6 +39,9 @@ import {Color} from '../../../colors/color';
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, AfterViewInit, OnInit {
+    @ViewChild(ColorMapSelectorComponent)
+    colorMapSelector!: ColorMapSelectorComponent;
+
     @Input() layer!: RasterLayer;
 
     symbology!: RasterSymbology;
@@ -168,8 +182,13 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
     }
 
     applyChanges(): void {
+        this.colorMapSelector.applyChanges();
         this.unappliedChanges = false;
         this.update();
+    }
+
+    getNotified(): void {
+        this.unappliedChanges = true;
     }
 
     getNoDataColor(): ColorAttributeInput {

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -39,7 +39,7 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
 
     scale: 'linear' | 'logarithmic' = 'linear';
 
-    unappliedChanges: boolean = false;
+    unappliedChanges = false;
 
     histogramData = new ReplaySubject<VegaChartData>(1);
     histogramLoading = new BehaviorSubject(false);

--- a/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
+++ b/projects/core/src/lib/layers/symbology/raster-symbology-editor/raster-symbology-editor.component.ts
@@ -251,14 +251,15 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
     }
 
     updateColorizerType(colorizerType: 'linearGradient' | 'logarithmicGradient' | 'palette'): void {
+        // TODO: Remove this once palettes are fully implemented
+        this.paletteSelected = colorizerType === 'linearGradient' || colorizerType === 'logarithmicGradient' ? false : true;
+
         if (this.getColorizerType() === colorizerType) {
-            this.paletteSelected = false;
             return;
         }
 
         if (colorizerType === 'palette' || this.getColorizerType() === 'palette') {
             // TODO: implement palette
-            this.paletteSelected = true;
             return;
         }
 
@@ -266,7 +267,6 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
             const breakpoints = this.symbology.colorizer.getBreakpoints();
             let noDataColor: Color;
             let defaultColor: Color;
-            this.paletteSelected = false;
 
             if (this.symbology.colorizer instanceof LogarithmicGradient) {
                 noDataColor = this.symbology.colorizer.noDataColor;
@@ -282,7 +282,6 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
             const breakpoints = this.symbology.colorizer.getBreakpoints();
             let noDataColor: Color;
             let defaultColor: Color;
-            this.paletteSelected = false;
 
             if (this.symbology.colorizer instanceof LinearGradient) {
                 noDataColor = this.symbology.colorizer.noDataColor;
@@ -296,7 +295,6 @@ export class RasterSymbologyEditorComponent implements OnChanges, OnDestroy, Aft
             this.symbology = this.symbology.cloneWith({colorizer});
         } else if (colorizerType === 'palette') {
             // TODO: implement palette
-            this.paletteSelected = true;
             return;
         }
 


### PR DESCRIPTION
- After making changes to the global layer properties inside the symbology editor, the changes are not immediately applied to the map view. Instead, the user gets notified of unapplied changes by the background color changing, the heading changing and the "Apply changes" button becoming active, as seen in attached screenshot. Pressing the button will apply changes to the active layer, return the button to inactive etc.
- "Colorizer Type" buttons now wrap, also seen in screenshot, to prevent some buttons being completely hidden on smaller screens
- Fixed a small typo in "Add Data" -> "Upload" ("Upload data from you local computer" -> "you" to "your")

![image](https://user-images.githubusercontent.com/57327151/201635576-4a260565-3dee-4929-8cc4-c4b6aab176e9.png)
