### PR TITLE
dont skip layer providers

### DIFF
--- a/projects/core/src/lib/datasets/add-data/add-data.component.ts
+++ b/projects/core/src/lib/datasets/add-data/add-data.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, ChangeDetectionStrategy, Input} from '@angular/core';
-import {filter, mergeMap, Observable, range, reduce, take} from 'rxjs';
+import {concatMap, first, Observable, range, reduce, take, takeWhile} from 'rxjs';
 import {LayerCollectionNavigationComponent} from '../../layer-collections/layer-collection-navigation/layer-collection-navigation.component';
 import {LayerCollectionService} from '../../layer-collections/layer-collection.service';
 import {LayoutService, SidenavConfig} from '../../layout.service';
@@ -47,12 +47,11 @@ export class AddDataComponent implements OnInit {
         const MAX_NUMBER_OF_QUERIES = 10;
         const BATCH_SIZE = 20;
         return range(0, MAX_NUMBER_OF_QUERIES).pipe(
-            mergeMap((i) => {
+            concatMap((i) => {
                 const start = i * BATCH_SIZE;
-                return layerService.getRootLayerCollectionItems(start, BATCH_SIZE);
+                return layerService.getRootLayerCollectionItems(start, BATCH_SIZE).pipe(first());
             }),
-            take(MAX_NUMBER_OF_QUERIES),
-            filter((collection) => collection.items.length > 0),
+            takeWhile((collection) => collection.items.length > 0),
             reduce((acc, collection) => {
                 const buttons: Array<AddDataButton> = collection.items.map((item) => ({
                     name: item.name,

--- a/projects/core/src/lib/datasets/add-data/add-data.component.ts
+++ b/projects/core/src/lib/datasets/add-data/add-data.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, ChangeDetectionStrategy, Input} from '@angular/core';
-import {mergeMap, Observable, range, reduce, takeWhile} from 'rxjs';
+import {filter, mergeMap, Observable, range, reduce, take} from 'rxjs';
 import {LayerCollectionNavigationComponent} from '../../layer-collections/layer-collection-navigation/layer-collection-navigation.component';
 import {LayerCollectionService} from '../../layer-collections/layer-collection.service';
 import {LayoutService, SidenavConfig} from '../../layout.service';
@@ -51,7 +51,8 @@ export class AddDataComponent implements OnInit {
                 const start = i * BATCH_SIZE;
                 return layerService.getRootLayerCollectionItems(start, BATCH_SIZE);
             }),
-            takeWhile((collection) => collection.items.length > 0),
+            take(MAX_NUMBER_OF_QUERIES),
+            filter((collection) => collection.items.length > 0),
             reduce((acc, collection) => {
                 const buttons: Array<AddDataButton> = collection.items.map((item) => ({
                     name: item.name,

--- a/projects/core/src/lib/datasets/add-data/add-data.component.ts
+++ b/projects/core/src/lib/datasets/add-data/add-data.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, ChangeDetectionStrategy, Input} from '@angular/core';
-import {concatMap, first, Observable, range, reduce, take, takeWhile} from 'rxjs';
+import {concatMap, first, Observable, range, reduce, takeWhile} from 'rxjs';
 import {LayerCollectionNavigationComponent} from '../../layer-collections/layer-collection-navigation/layer-collection-navigation.component';
 import {LayerCollectionService} from '../../layer-collections/layer-collection.service';
 import {LayoutService, SidenavConfig} from '../../layout.service';


### PR DESCRIPTION
Sometimes the requests for empty collections are faster then requests that return collections with data. I replaced the takeWhile with a take and a filter