### PR TITLE
Fix under color not being displayed

### DIFF
--- a/projects/core/src/lib/colors/colorizer.model.ts
+++ b/projects/core/src/lib/colors/colorizer.model.ts
@@ -161,7 +161,7 @@ export class LinearGradient extends Colorizer {
             breakpoints: this.breakpoints.map((b) => b.toDict()),
             noDataColor: colorToDict(this.noDataColor),
             overColor: colorToDict(this.overColor),
-            underColor: colorToDict(this.overColor),
+            underColor: colorToDict(this.underColor),
         };
     }
 


### PR DESCRIPTION
Undercolor and overcolor are now displayed correctly for linear gradient
![image](https://github.com/geo-engine/geoengine-ui/assets/57327151/3a30d7ad-931c-4d13-9989-a4febc58f779)
