### PR TITLE
Color editing possible

### DIFF
--- a/projects/core/src/lib/colors/color-table-editor/color-table-editor.component.ts
+++ b/projects/core/src/lib/colors/color-table-editor/color-table-editor.component.ts
@@ -24,9 +24,14 @@ export class ColorTableEditorComponent implements OnInit {
     constructor(private ref: ChangeDetectorRef) {}
 
     ngOnInit(): void {
+        this.updateColorAttributes();
+    }
+
+    updateColorAttributes(): void {
         this.colorAttributes = this.colorTable.map((color: ColorBreakpoint) => {
             return {key: color.value.toString(), value: color.color};
         });
+        this.ref.detectChanges();
     }
 
     /**

--- a/projects/core/src/lib/layers/symbology/raster-gradient-symbology-editor/raster-gradient-symbology-editor.component.html
+++ b/projects/core/src/lib/layers/symbology/raster-gradient-symbology-editor/raster-gradient-symbology-editor.component.html
@@ -75,3 +75,18 @@
         <button mat-stroked-button (click)="createColorTable()">Create color table</button>
     </mat-card-content>
 </mat-card>
+<mat-card>
+    <mat-card-header>
+        <mat-card-title-group>
+            <mat-card-title>Color Table</mat-card-title>
+            <mat-card-subtitle>Edit the color table</mat-card-subtitle>
+            <mat-icon class="icon">looks</mat-icon>
+        </mat-card-title-group>
+    </mat-card-header>
+    <mat-card-content>
+        <geoengine-color-table-editor
+            [colorTable]="colorTable"
+            (colorTableChanged)="updateColorTable($event)"
+        ></geoengine-color-table-editor>
+    </mat-card-content>
+</mat-card>


### PR DESCRIPTION
Color palette tabs don't get updated on "Create Color Table", only after closing and re-opening the dialog or switching to another colorizer and back.
`raster-gradient-symbology-editor.component.ts` line 236, `createColorTable` seems like the best option to fix it, but I had no success so far.