### PR TITLE
Measurement editing

### DIFF
--- a/projects/common/src/lib/common.module.ts
+++ b/projects/common/src/lib/common.module.ts
@@ -123,7 +123,6 @@ const COMMON_COMPONENTS = [
     LineIconComponent,
     LineIconComponent,
     LoginComponent,
-    MeasurementComponent,
     NumberParamEditorComponent,
     PercentileBreakpointSelectorComponent,
     PercentileBreakpointSelectorComponent,
@@ -166,6 +165,7 @@ const FXFLEX_LEGACY_DIRECTIVES = [FxFlexDirective, FxLayoutDirective, FxLayoutGa
         AngularCommonModule,
         ScrollingModule,
         OgrDatasetComponent,
+        MeasurementComponent,
         RouterOutlet,
         RouterLink,
         RouterLinkActive,
@@ -183,6 +183,7 @@ const FXFLEX_LEGACY_DIRECTIVES = [FxFlexDirective, FxLayoutDirective, FxLayoutGa
         ScrollingModule,
         NgxMatSelectSearchModule,
         OgrDatasetComponent,
+        MeasurementComponent,
     ],
 })
 export class CommonModule {}

--- a/projects/common/src/lib/datasets/ogr-dataset/ogr-dataset.component.html
+++ b/projects/common/src/lib/datasets/ogr-dataset/ogr-dataset.component.html
@@ -205,4 +205,25 @@
         <mat-label>Spatial Reference</mat-label>
         <input matInput type="text" formControlName="spatialReference" />
     </mat-form-field>
+
+    <mat-form-field class="column">
+        <mat-label>Column</mat-label>
+        <mat-select [ngModel]="selectedColumn()" (ngModelChange)="setSelectedColumn($event)" [ngModelOptions]="{standalone:true}"
+                    (selectionChange)="onColumnMatSelectChange($event)">
+            <!--
+            this causes an infinite loop in.
+            I think that's because we create a new column vector every time we call this method?
+            -->
+            <!--            <mat-option *ngFor="let col of _columns" [value]="col">{{ col }}</mat-option>-->
+            @for (col of sortedColumns(); track col.name) {
+                <mat-option [value]="col.name">{{ col.name }}</mat-option>
+            }
+        </mat-select>
+    </mat-form-field>
+    <geoengine-measurement
+        [measurement]="newMeasurementForColumn()"
+        (measurementChange)="onMeasurementChange($event)"
+        (onInputChange)="markDirty()"
+    ></geoengine-measurement>
+
 </form>

--- a/projects/common/src/lib/measurement/measurement.component.html
+++ b/projects/common/src/lib/measurement/measurement.component.html
@@ -21,11 +21,11 @@
         <div class="flex-container" *ngFor="let class of classificationMeasurement.classes | keyvalue">
             <mat-form-field appearance="fill">
                 <mat-label>Class value</mat-label>
-                <input matInput type="number" required="true" [(ngModel)]="class.key" />
+                <input matInput type="number" required="true" [(ngModel)]="class.key" (input)="inputChange($event)" />
             </mat-form-field>
             <mat-form-field appearance="fill">
                 <mat-label>Class label</mat-label>
-                <input matInput type="text" required="true" [(ngModel)]="class.value" />
+                <input matInput type="text" required="true" [(ngModel)]="class.value" (input)="inputChange($event)" />
             </mat-form-field>
 
             <button mat-icon-button (click)="removeClass(class.key)">
@@ -37,11 +37,11 @@
             <div class="flex-container">
                 <mat-form-field appearance="fill">
                     <mat-label>New class value</mat-label>
-                    <input matInput type="number" formControlName="key" />
+                    <input matInput type="number" formControlName="key" (input)="inputChange($event)" />
                 </mat-form-field>
                 <mat-form-field appearance="fill">
                     <mat-label>New class label</mat-label>
-                    <input matInput type="text" formControlName="value" />
+                    <input matInput type="text" formControlName="value" (input)="inputChange($event)" />
                 </mat-form-field>
 
                 <button mat-icon-button [disabled]="!addClassForm.valid" (click)="addClass()">
@@ -55,11 +55,11 @@
         <div class="flex-container">
             <mat-form-field appearance="fill">
                 <mat-label>Measurement</mat-label>
-                <input matInput type="text" required="true" [(ngModel)]="continuousMeasurement.measurement" />
+                <input matInput type="text" required="true" [(ngModel)]="continuousMeasurement.measurement" (input)="inputChange($event)" />
             </mat-form-field>
             <mat-form-field appearance="fill">
                 <mat-label>Unit</mat-label>
-                <input matInput type="text" [(ngModel)]="continuousMeasurement.unit" />
+                <input matInput type="text" [(ngModel)]="continuousMeasurement.unit" (input)="inputChange($event)" />
             </mat-form-field>
         </div>
     }

--- a/projects/common/src/lib/measurement/measurement.component.html
+++ b/projects/common/src/lib/measurement/measurement.component.html
@@ -1,5 +1,4 @@
 <div>
-    Output Measurement:
     <mat-button-toggle-group
         id="measurement-type"
         [multiple]="false"
@@ -52,15 +51,15 @@
         </form>
     }
 
-    @if (measurement.type === MeasurementType.Continuous && continousMeasurement) {
+    @if (measurement.type === MeasurementType.Continuous && continuousMeasurement) {
         <div class="flex-container">
             <mat-form-field appearance="fill">
                 <mat-label>Measurement</mat-label>
-                <input matInput type="text" required="true" [(ngModel)]="continousMeasurement.measurement" />
+                <input matInput type="text" required="true" [(ngModel)]="continuousMeasurement.measurement" />
             </mat-form-field>
             <mat-form-field appearance="fill">
                 <mat-label>Unit</mat-label>
-                <input matInput type="text" [(ngModel)]="continousMeasurement.unit" />
+                <input matInput type="text" [(ngModel)]="continuousMeasurement.unit" />
             </mat-form-field>
         </div>
     }

--- a/projects/common/src/lib/measurement/measurement.component.ts
+++ b/projects/common/src/lib/measurement/measurement.component.ts
@@ -1,7 +1,8 @@
 import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
 import {ClassificationMeasurement, ContinuousMeasurement, Measurement, UnitlessMeasurement} from '@geoengine/openapi-client';
-import {CommonModule, MATERIAL_MODULES} from '../common.module';
+import {MATERIAL_MODULES} from '../common.module';
+import {CommonModule as AngularCommonModule} from '@angular/common';
 
 enum MeasurementType {
     Classification = 'classification',
@@ -18,12 +19,13 @@ interface AddClassForm {
     selector: 'geoengine-measurement',
     templateUrl: './measurement.component.html',
     styleUrl: './measurement.component.css',
-    imports: [MATERIAL_MODULES, FormsModule, ReactiveFormsModule],
+    imports: [MATERIAL_MODULES, FormsModule, ReactiveFormsModule, AngularCommonModule],
 })
 export class MeasurementComponent implements OnChanges {
     @Input() measurement!: Measurement;
 
     @Output() measurementChange = new EventEmitter<Measurement>();
+    @Output() onInputChange = new EventEmitter<Event>();
 
     MeasurementType = MeasurementType;
 
@@ -51,6 +53,12 @@ export class MeasurementComponent implements OnChanges {
         this.initMeasurement(this.measurement);
     }
 
+    public reset() {
+        this.classificationMeasurement = undefined;
+        this.continuousMeasurement = undefined;
+        this.unitlessMeasurement = undefined;
+    }
+
     getMeasurementType(): MeasurementType {
         switch (this.measurement.type) {
             case 'classification':
@@ -76,9 +84,9 @@ export class MeasurementComponent implements OnChanges {
                 break;
             case MeasurementType.Unitless:
                 this.unitlessMeasurement = {type: 'unitless'};
+                break;
         }
         this.measurement = measurement;
-        this.measurementChange.emit(this.measurement);
     }
 
     updateMeasurementType(type: MeasurementType): void {
@@ -139,5 +147,9 @@ export class MeasurementComponent implements OnChanges {
 
         this.addClassForm.reset();
         this.addClassForm.markAsPristine();
+    }
+
+    inputChange(content: Event) {
+        this.onInputChange.emit(content);
     }
 }

--- a/projects/common/src/lib/measurement/measurement.component.ts
+++ b/projects/common/src/lib/measurement/measurement.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {ClassificationMeasurement, ContinuousMeasurement, Measurement, UnitlessMeasurement} from '@geoengine/openapi-client';
 
@@ -19,7 +19,7 @@ interface AddClassForm {
     styleUrl: './measurement.component.css',
     standalone: false,
 })
-export class MeasurementComponent {
+export class MeasurementComponent implements OnChanges {
     @Input() measurement!: Measurement;
 
     @Output() measurementChange = new EventEmitter<Measurement>();
@@ -27,7 +27,7 @@ export class MeasurementComponent {
     MeasurementType = MeasurementType;
 
     classificationMeasurement?: ClassificationMeasurement;
-    continousMeasurement?: ContinuousMeasurement;
+    continuousMeasurement?: ContinuousMeasurement;
     unitlessMeasurement?: UnitlessMeasurement;
 
     addClassForm: FormGroup<AddClassForm> = new FormGroup<AddClassForm>({
@@ -41,12 +41,13 @@ export class MeasurementComponent {
         }),
     });
 
-    constructor() {
+    ngOnChanges() {
         if (!this.measurement) {
             this.measurement = {
                 type: 'unitless',
             };
         }
+        this.initMeasurement(this.measurement);
     }
 
     getMeasurementType(): MeasurementType {
@@ -58,6 +59,25 @@ export class MeasurementComponent {
             case 'unitless':
                 return MeasurementType.Unitless;
         }
+    }
+
+    /**
+     * If created with a measurement as @Input, set the appropriate fields
+     * for Classification and Continuous MeasurementType's.
+     */
+    private initMeasurement(measurement: Measurement): void {
+        switch (measurement.type) {
+            case MeasurementType.Classification:
+                this.classificationMeasurement = measurement;
+                break;
+            case MeasurementType.Continuous:
+                this.continuousMeasurement = measurement;
+                break;
+            case MeasurementType.Unitless:
+                this.unitlessMeasurement = {type: 'unitless'};
+        }
+        this.measurement = measurement;
+        this.measurementChange.emit(this.measurement);
     }
 
     updateMeasurementType(type: MeasurementType): void {
@@ -74,14 +94,14 @@ export class MeasurementComponent {
                 this.measurement = this.classificationMeasurement;
                 break;
             case MeasurementType.Continuous:
-                if (!this.continousMeasurement) {
-                    this.continousMeasurement = {
+                if (!this.continuousMeasurement) {
+                    this.continuousMeasurement = {
                         type: 'continuous',
                         measurement: 'continuous',
                     };
                 }
 
-                this.measurement = this.continousMeasurement;
+                this.measurement = this.continuousMeasurement;
                 break;
             case MeasurementType.Unitless:
                 if (!this.unitlessMeasurement) {
@@ -95,6 +115,7 @@ export class MeasurementComponent {
                 };
                 break;
         }
+        this.measurementChange.emit(this.measurement);
     }
 
     removeClass(key: string) {

--- a/projects/common/src/lib/measurement/measurement.component.ts
+++ b/projects/common/src/lib/measurement/measurement.component.ts
@@ -1,6 +1,7 @@
 import {Component, EventEmitter, Input, OnChanges, Output} from '@angular/core';
-import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
 import {ClassificationMeasurement, ContinuousMeasurement, Measurement, UnitlessMeasurement} from '@geoengine/openapi-client';
+import {CommonModule, MATERIAL_MODULES} from '../common.module';
 
 enum MeasurementType {
     Classification = 'classification',
@@ -17,7 +18,7 @@ interface AddClassForm {
     selector: 'geoengine-measurement',
     templateUrl: './measurement.component.html',
     styleUrl: './measurement.component.css',
-    standalone: false,
+    imports: [MATERIAL_MODULES, FormsModule, ReactiveFormsModule],
 })
 export class MeasurementComponent implements OnChanges {
     @Input() measurement!: Measurement;

--- a/projects/core/src/lib/operators/dialogs/expression-operator/expression-operator.component.html
+++ b/projects/core/src/lib/operators/dialogs/expression-operator/expression-operator.component.html
@@ -41,6 +41,7 @@
                 <input matInput type="text" formControlName="outputBandName" />
             </mat-form-field>
 
+            Output Measurement:
             <geoengine-measurement></geoengine-measurement>
         </ng-container>
 

--- a/projects/manager/src/app/datasets/loading-info/gdal-metadata-list/gdal-metadata-list.component.html
+++ b/projects/manager/src/app/datasets/loading-info/gdal-metadata-list/gdal-metadata-list.component.html
@@ -31,6 +31,13 @@
             <mat-label>Band Name</mat-label>
             <input matInput type="text" formControlName="bandName" />
         </mat-form-field>
+
+        <ng-container *ngIf="metaData as meta">
+            <geoengine-measurement
+                [measurement]="meta.resultDescriptor.bands[0].measurement || {type: 'unitless'}"
+                (measurementChange)="onMeasurementChange()"
+            ></geoengine-measurement>
+        </ng-container>
     </div>
 
     <div class="container">

--- a/projects/manager/src/app/datasets/loading-info/gdal-metadata-list/gdal-metadata-list.component.ts
+++ b/projects/manager/src/app/datasets/loading-info/gdal-metadata-list/gdal-metadata-list.component.ts
@@ -1,12 +1,13 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, SimpleChanges} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, SimpleChanges, ViewChild} from '@angular/core';
 import {AbstractControl, FormArray, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators} from '@angular/forms';
 import {GdalDatasetParametersComponent, GdalDatasetParametersForm} from '../gdal-dataset-parameters/gdal-dataset-parameters.component';
-import {DatasetsService, TimeInterval, errorToText} from '@geoengine/common';
+import {DatasetsService, MeasurementComponent, TimeInterval, errorToText} from '@geoengine/common';
 import moment from 'moment';
 import {
     DataPath,
     GdalDatasetParameters,
     GdalMetaDataList,
+    Measurement,
     MetaDataDefinition,
     RasterDataType,
     RasterResultDescriptor,
@@ -47,6 +48,8 @@ export class GdalMetadataListComponent implements OnChanges {
     @Input() dataPath?: DataPath;
 
     @Input() metaData?: GdalMetaDataList;
+
+    @ViewChild(MeasurementComponent) measurementComponent?: MeasurementComponent;
 
     selectedTimeSlice = 0;
 
@@ -160,13 +163,13 @@ export class GdalMetadataListComponent implements OnChanges {
 
         const resultDescriptorControl = this.form.controls.rasterResultDescriptor.controls;
 
+        const measurement = this.measurementComponent?.measurement || {type: 'unitless'};
+
         const resultDescriptor: RasterResultDescriptor = {
             bands: [
                 {
                     name: resultDescriptorControl.bandName.value,
-                    measurement: {
-                        type: 'unitless',
-                    },
+                    measurement: measurement,
                 },
             ],
             spatialReference: resultDescriptorControl.spatialReference.value,
@@ -322,6 +325,10 @@ export class GdalMetadataListComponent implements OnChanges {
         });
 
         return form;
+    }
+
+    onMeasurementChange() {
+        this.form.markAsDirty();
     }
 }
 


### PR DESCRIPTION
Allows for changing the `Measurements` in the `LoadingInformation` for Gdal and Ogr Sources.

## GdalSources

![gdalsources](https://github.com/user-attachments/assets/5cd1f498-cc5d-4320-9b58-27e1610a5d49)

## OgrSources

![ogrsources](https://github.com/user-attachments/assets/424fde36-f6b4-42c6-96c2-94c95e61d039)

Currently the `class values` for the `classification measurement` are typed for integers other input is not allowed.
I think this makes it impossible for declaring a proper classification measurement for `text` or `float` columns.

I did not implement this in the frontend yet, as I've seen that the backend defines the type as 

```rust
pub struct ClassificationMeasurement {
    pub measurement: String,
    pub classes: HashMap<u8, String>,
}
```

and I am not 100% sure if this should be even possible.

## Changes I've made

### Measurement Component

- The `MeasurementComponent` has been made a standalone component. I made this change, because I got a cyclic import problem with using the `MeasurementComponent` in the `OgrDatasetComponent`.
- A new `@Output() onInputChange = new EventEmitter<Event>();` that fires every time one of the text input fields changes (used to mark the form as dirty)
- `@Output() measurementChange = new EventEmitter<Measurement>();` now fires after measurement changes (didnt fire at all before)
- change `constructor` to `ngOnChange` and setup the measurement appropriately if one is given as `@Input`

### GdalMetadataListComponent and OgrDatasetComponent
- both now have a child `MeasurementComponent`

#### OgrDatasetComponent
- holds additional info about the columns in the Dataset
- tracks which dataset's measurement was edited last and which is being currently edited (to properly save the new measurement`
- now implements `OnInit` to setup the currently selected column for the measurement component