### PR TITLE
fix(manager): save NoDataValue in `gdal-dataset-parameters` correctly

### DIFF
--- a/projects/manager/src/app/datasets/loading-info/gdal-dataset-parameters/gdal-dataset-parameters.component.html
+++ b/projects/manager/src/app/datasets/loading-info/gdal-dataset-parameters/gdal-dataset-parameters.component.html
@@ -51,7 +51,7 @@
         </mat-form-field>
         <mat-form-field appearance="fill">
             <mat-label>No data value (leave empty if there is none)</mat-label>
-            <input matInput type="number" formControlName="height" />
+            <input matInput type="number" formControlName="noDataValue" />
         </mat-form-field>
     </div>
 


### PR DESCRIPTION
The `noDataValue` was not bound to the form field for "No Data Value", instead it was bound to height in `gdal-dataset-parameters.component.html`.