### PR TITLE
ci: disable nightly schedule in containers workflow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -2,8 +2,8 @@ name: Create containers
 
 on:
   # run every night
-  schedule:
-    - cron: "0 22 * * *"
+  # schedule:
+  #   - cron: "0 22 * * *"
 
   # schedule manually
   workflow_dispatch:


### PR DESCRIPTION
Comment out the scheduled cron job for nightly runs.